### PR TITLE
ci(workflows): sync release and build workflows from refactor

### DIFF
--- a/.github/workflows/build-matrix.yml
+++ b/.github/workflows/build-matrix.yml
@@ -1,0 +1,391 @@
+name: Build Matrix Reusable
+
+on:
+  workflow_call:
+    inputs:
+      checkout_ref:
+        description: Optional git ref to checkout
+        required: false
+        default: ''
+        type: string
+      build_type:
+        description: CMake build type for Unix builds
+        required: false
+        default: Debug
+        type: string
+      windows_preset:
+        description: CMake preset used for Windows configure/build
+        required: false
+        default: windows-msvc-ninja-debug
+        type: string
+      windows_artifact_dir:
+        description: Build directory that contains Windows output artifacts
+        required: false
+        default: build/windows-msvc-ninja-debug
+        type: string
+      run_tests:
+        description: Run ctest for matrix entries that do not opt out
+        required: false
+        default: true
+        type: boolean
+      include_clang_tidy_linux:
+        description: Install and verify clang-tidy on Linux builds
+        required: false
+        default: true
+        type: boolean
+      artifact_prefix:
+        description: Optional artifact name prefix
+        required: false
+        default: ''
+        type: string
+      cache_key_prefix:
+        description: Optional cache key prefix
+        required: false
+        default: ''
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: linux-x86_64
+            os: ubuntu-latest
+            platform: linux
+            arch: x86_64
+            triplet: arch-env
+            skip_tests: false
+          - name: linux-i686
+            os: ubuntu-latest
+            platform: linux
+            arch: i686
+            triplet: arch-env
+            skip_tests: true
+          - name: linux-armv7l
+            os: ubuntu-latest
+            platform: linux
+            arch: armv7l
+            triplet: arch-env
+            skip_tests: true
+          - name: linux-aarch64
+            os: ubuntu-latest
+            platform: linux
+            arch: aarch64
+            triplet: arch-env
+            skip_tests: true
+          - name: windows-x64
+            os: windows-latest
+            platform: windows
+            arch: x64
+            msvc_arch: x64
+            triplet: x64-windows-static
+            skip_tests: false
+          - name: windows-x86
+            os: windows-latest
+            platform: windows
+            arch: x86
+            msvc_arch: x86
+            triplet: x86-windows-static
+            skip_tests: true
+          - name: windows-arm64ec
+            os: windows-latest
+            platform: windows
+            arch: arm64ec
+            msvc_arch: amd64_arm64
+            triplet: arm64ec-windows-static
+            skip_tests: true
+          - name: macos-universal
+            os: macos-latest
+            platform: macos
+            arch: x86_64;arm64
+            triplet: arch-env
+            skip_tests: false
+    env:
+      ARCH: ${{ matrix.arch }}
+      VCPKG_OVERLAY_TRIPLETS: cmake/vcpkg-triplets
+
+    steps:
+      - name: Checkout (default ref)
+        if: inputs.checkout_ref == ''
+        uses: actions/checkout@v4
+
+      - name: Checkout (requested ref)
+        if: inputs.checkout_ref != ''
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.checkout_ref }}
+
+      - name: Resolve vcpkg toolchain Unix
+        if: runner.os != 'Windows'
+        id: vcpkg-unix
+        shell: bash
+        run: |
+          set -euo pipefail
+          candidates=()
+          if [ -n "${VCPKG_INSTALLATION_ROOT:-}" ]; then
+            candidates+=("${VCPKG_INSTALLATION_ROOT}/scripts/buildsystems/vcpkg.cmake")
+          fi
+          candidates+=("$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake")
+
+          for candidate in "${candidates[@]}"; do
+            if [ -f "$candidate" ]; then
+              echo "toolchain=$candidate" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          done
+
+          echo "Unable to locate vcpkg toolchain file on runner." >&2
+          exit 1
+
+      - name: Resolve vcpkg toolchain Windows
+        if: runner.os == 'Windows'
+        id: vcpkg-windows
+        shell: pwsh
+        run: |
+          $candidates = @()
+          if ($env:VCPKG_INSTALLATION_ROOT) {
+            $candidates += (Join-Path $env:VCPKG_INSTALLATION_ROOT 'scripts/buildsystems/vcpkg.cmake')
+          }
+          $candidates += 'C:\vcpkg\scripts\buildsystems\vcpkg.cmake'
+
+          foreach ($candidate in $candidates) {
+            if (Test-Path $candidate) {
+              "toolchain=$candidate" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+              exit 0
+            }
+          }
+
+          throw 'Unable to locate vcpkg toolchain file on runner.'
+
+      - name: Cache vcpkg and CMake deps
+        uses: actions/cache@v4
+        with:
+          path: |
+            build/vcpkg_installed
+            build/_deps
+          key: >-
+            ${{ inputs.cache_key_prefix }}${{ runner.os }}-${{ matrix.arch }}-${{ hashFiles('CMakeLists.txt', 'cmake/**/*.cmake', 'cmake/vcpkg-triplets/*.cmake', 'vcpkg.json') }}
+
+      - name: Setup Linux cross dependencies
+        if: matrix.platform == 'linux'
+        shell: bash
+        run: |
+          set -euo pipefail
+          configure_apt_sources() {
+            local target_arch="$1"
+            . /etc/os-release
+
+            if [ -f /etc/apt/sources.list.d/ubuntu.sources ]; then
+              # Keep native packages on archive.ubuntu.com and use ports only for ARM targets.
+              # Avoid security/backports suites for cross-arch parity on ubuntu-latest.
+              printf '%s\n' \
+                'Types: deb' \
+                'Architectures: amd64 i386' \
+                'URIs: http://archive.ubuntu.com/ubuntu/' \
+                "Suites: ${VERSION_CODENAME} ${VERSION_CODENAME}-updates" \
+                'Components: main universe restricted multiverse' \
+                'Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg' \
+                | sudo tee /etc/apt/sources.list.d/ubuntu.sources > /dev/null
+
+              sudo rm -f /etc/apt/sources.list.d/ubuntu-ports.sources
+              if [[ "$target_arch" =~ ^(arm64|armhf)$ ]]; then
+                printf '%s\n' \
+                  'Types: deb' \
+                  "Architectures: ${target_arch}" \
+                  'URIs: http://ports.ubuntu.com/ubuntu-ports/' \
+                  "Suites: ${VERSION_CODENAME} ${VERSION_CODENAME}-updates" \
+                  'Components: main universe restricted multiverse' \
+                  'Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg' \
+                  | sudo tee /etc/apt/sources.list.d/ubuntu-ports.sources > /dev/null
+              fi
+            elif [ -f /etc/apt/sources.list ]; then
+              printf '%s\n' \
+                "deb [arch=amd64,i386] http://archive.ubuntu.com/ubuntu/ ${VERSION_CODENAME} main universe restricted multiverse" \
+                "deb [arch=amd64,i386] http://archive.ubuntu.com/ubuntu/ ${VERSION_CODENAME}-updates main universe restricted multiverse" \
+                | sudo tee /etc/apt/sources.list > /dev/null
+
+              sudo rm -f /etc/apt/sources.list.d/ports.list
+              if [[ "$target_arch" =~ ^(arm64|armhf)$ ]]; then
+                printf '%s\n' \
+                  "deb [arch=${target_arch}] http://ports.ubuntu.com/ubuntu-ports/ ${VERSION_CODENAME} main universe restricted multiverse" \
+                  "deb [arch=${target_arch}] http://ports.ubuntu.com/ubuntu-ports/ ${VERSION_CODENAME}-updates main universe restricted multiverse" \
+                  | sudo tee /etc/apt/sources.list.d/ports.list > /dev/null
+              fi
+            fi
+          }
+
+          install_deps() {
+            local target_arch="$1"; shift
+            local native=("$@" php-cli qemu-user-binfmt)
+            local target=(
+              libboost-dev libcurl4-openssl-dev libsqlite3-dev libssl-dev
+              libxml2-dev zlib1g-dev
+            )
+
+            if [ "${{ inputs.include_clang_tidy_linux }}" = 'true' ]; then
+              native+=(clang-tidy)
+            fi
+
+            sudo dpkg --add-architecture "$target_arch"
+            configure_apt_sources "$target_arch"
+            sudo rm -rf /var/lib/apt/lists/*
+            sudo apt-get update -qq
+            sudo apt-get install -y -qq aptitude > /dev/null
+            sudo aptitude install -yR "${native[@]}" "${target[@]/%/:$target_arch}" > /dev/null
+            sudo aptitude install -yR "${native[@]}" > /dev/null
+          }
+
+          case "$ARCH" in
+            x86_64)
+              install_deps amd64
+              ;;
+            i686)
+              install_deps i386 g++-multilib
+              {
+                echo "TOOLCHAIN=${GITHUB_WORKSPACE}/cmake/linux-cross.cmake"
+                echo "TOOLCHAIN_PREFIX=i386-linux-gnu"
+              } >> "$GITHUB_ENV"
+              ;;
+            armv7l)
+              install_deps armhf g++-arm-linux-gnueabihf
+              {
+                echo "TOOLCHAIN=${GITHUB_WORKSPACE}/cmake/linux-cross.cmake"
+                echo "TOOLCHAIN_PREFIX=arm-linux-gnueabihf"
+              } >> "$GITHUB_ENV"
+              ;;
+            aarch64)
+              install_deps arm64 g++-aarch64-linux-gnu
+              {
+                echo "TOOLCHAIN=${GITHUB_WORKSPACE}/cmake/linux-cross.cmake"
+                echo "TOOLCHAIN_PREFIX=aarch64-linux-gnu"
+              } >> "$GITHUB_ENV"
+              ;;
+            *)
+              echo "Unsupported ARCH: $ARCH" >&2
+              exit 1
+              ;;
+          esac
+
+      - name: Setup macOS build environment
+        if: matrix.platform == 'macos'
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          brew update
+          brew install llvm
+          echo "$(brew --prefix llvm)/bin" >> "$GITHUB_PATH"
+          "$(brew --prefix llvm)/bin/clang-tidy" --version
+
+          echo "DEPLOY_TARGET=11.0" >> "$GITHUB_ENV"
+
+          if [ -d /Library/Frameworks/Mono.framework ]; then
+            sudo rm -rf /Library/Frameworks/Mono.framework
+          fi
+
+      - name: Verify clang-tidy Linux
+        if: matrix.platform == 'linux' && inputs.include_clang_tidy_linux
+        shell: bash
+        run: clang-tidy --version
+
+      - name: Setup MSVC developer command prompt
+        if: matrix.platform == 'windows'
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: ${{ matrix.msvc_arch }}
+
+      - name: Verify clang-tidy Windows
+        if: matrix.platform == 'windows' && inputs.include_clang_tidy_linux
+        shell: pwsh
+        run: clang-tidy --version
+
+      - name: Setup ARM64EC flags
+        if: matrix.platform == 'windows' && matrix.arch == 'arm64ec'
+        shell: pwsh
+        run: |
+          'CFLAGS=-arm64EC' | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+          'CXXFLAGS=-arm64EC' | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+
+      - name: Configure Unix
+        if: runner.os != 'Windows'
+        env:
+          VCPKG_TOOLCHAIN: ${{ steps.vcpkg-unix.outputs.toolchain }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          cmake_args=(
+            -B build
+            -DCMAKE_BUILD_TYPE=${{ inputs.build_type }}
+            -DCMAKE_TOOLCHAIN_FILE="$VCPKG_TOOLCHAIN"
+            -DVCPKG_TARGET_TRIPLET="${{ matrix.triplet }}"
+            -DCMAKE_OSX_ARCHITECTURES="$ARCH"
+          )
+
+          if [ -n "${DEPLOY_TARGET:-}" ]; then
+            cmake_args+=("-DCMAKE_OSX_DEPLOYMENT_TARGET=${DEPLOY_TARGET}")
+          fi
+
+          if [ -n "${TOOLCHAIN:-}" ]; then
+            cmake_args+=("-DVCPKG_CHAINLOAD_TOOLCHAIN_FILE=${TOOLCHAIN}")
+          fi
+
+          cmake "${cmake_args[@]}"
+
+      - name: Configure Windows
+        if: runner.os == 'Windows'
+        env:
+          VCPKG_TOOLCHAIN: ${{ steps.vcpkg-windows.outputs.toolchain }}
+        shell: pwsh
+        run: |
+          cmake --preset ${{ inputs.windows_preset }} `
+            -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_TOOLCHAIN" `
+            -DVCPKG_TARGET_TRIPLET="${{ matrix.triplet }}"
+
+      - name: Build Unix
+        if: runner.os != 'Windows'
+        shell: bash
+        run: cmake --build build
+
+      - name: Build Windows
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: cmake --build --preset ${{ inputs.windows_preset }}
+
+      - name: Test Unix
+        if: runner.os != 'Windows' && inputs.run_tests && !matrix.skip_tests
+        shell: bash
+        run: ctest --test-dir build --output-on-failure
+
+      - name: Test Windows
+        if: runner.os == 'Windows' && inputs.run_tests && !matrix.skip_tests
+        shell: pwsh
+        run: ctest --test-dir ${{ inputs.windows_artifact_dir }} --output-on-failure
+
+      - name: Upload Linux artifacts
+        if: always() && matrix.platform == 'linux'
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ inputs.artifact_prefix != '' && format('{0}-{1}', inputs.artifact_prefix, matrix.name) || matrix.name }}
+          path: build/reaper_*.so
+
+      - name: Upload macOS artifacts
+        if: always() && matrix.platform == 'macos'
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ inputs.artifact_prefix != '' && format('{0}-{1}', inputs.artifact_prefix, matrix.name) || matrix.name }}
+          path: build/reaper_*.dylib
+
+      - name: Upload Windows artifacts
+        if: always() && matrix.platform == 'windows'
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ inputs.artifact_prefix != '' && format('{0}-{1}', inputs.artifact_prefix, matrix.name) || matrix.name }}
+          path: |
+            ${{ inputs.windows_artifact_dir }}/reaper_*.dll
+            ${{ inputs.windows_artifact_dir }}/reaper_*.pdb

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,337 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    uses: ./.github/workflows/build-matrix.yml
+    with:
+      build_type: Debug
+      windows_preset: windows-msvc-ninja-debug
+      windows_artifact_dir: build/windows-msvc-ninja-debug
+      run_tests: true
+      include_clang_tidy_linux: true
+
+  clang-format-report:
+    name: clang-format report
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install clang-format and gersemi (Linuxbrew)
+        shell: bash
+        run: |
+          set -euo pipefail
+          eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+          brew update
+          brew install clang-format gersemi
+          echo "$(brew --prefix clang-format)/bin" >> "$GITHUB_PATH"
+          clang-format --version
+          gersemi --version
+
+      - name: Check formatting
+        shell: bash
+        run: |
+          set -euo pipefail
+          mapfile -t files < <(git ls-files \
+            '*.c' '*.cc' '*.cpp' '*.cxx' '*.h' '*.hpp' '*.hxx' '*.inl')
+
+          if [ "${#files[@]}" -eq 0 ]; then
+            echo "No format-managed files found."
+            exit 0
+          fi
+
+          clang-format --dry-run --Werror "${files[@]}"
+
+      - name: Check CMake formatting
+        shell: bash
+        run: |
+          set -euo pipefail
+          eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+          mapfile -t cmake_files < <(git ls-files \
+            'CMakeLists.txt' '*.cmake')
+
+          if [ "${#cmake_files[@]}" -eq 0 ]; then
+            echo "No CMake files found."
+            exit 0
+          fi
+
+          gersemi --check "${cmake_files[@]}"
+
+  tooling-linux:
+    name: Tooling Linux configure-build-test + clang-tidy
+    runs-on: ubuntu-latest
+    env:
+      ARCH: x86_64
+      VCPKG_OVERLAY_TRIPLETS: cmake/vcpkg-triplets
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install tooling dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ninja-build clang clang-tidy
+
+      - name: Resolve vcpkg toolchain
+        id: vcpkg
+        shell: bash
+        run: |
+          set -euo pipefail
+          candidates=()
+          if [ -n "${VCPKG_INSTALLATION_ROOT:-}" ]; then
+            candidates+=("${VCPKG_INSTALLATION_ROOT}/scripts/buildsystems/vcpkg.cmake")
+          fi
+          candidates+=("$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake")
+
+          for candidate in "${candidates[@]}"; do
+            if [ -f "$candidate" ]; then
+              echo "toolchain=$candidate" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          done
+
+          echo "Unable to locate vcpkg toolchain file on runner." >&2
+          exit 1
+
+      - name: Cache vcpkg and CMake deps
+        uses: actions/cache@v4
+        with:
+          path: |
+            build/tooling/vcpkg_installed
+            build/tooling/_deps
+          key: >-
+            tooling-linux-${{ hashFiles('CMakeLists.txt', 'cmake/**/*.cmake', 'cmake/vcpkg-triplets/*.cmake', 'vcpkg.json', '.clang-tidy', '.clang-format') }}
+
+      - name: Configure
+        shell: bash
+        run: |
+          set -euo pipefail
+          cmake -B build/tooling -G Ninja \
+            -DCMAKE_BUILD_TYPE=Debug \
+            -DCMAKE_C_COMPILER=clang \
+            -DCMAKE_CXX_COMPILER=clang++ \
+            -DCMAKE_TOOLCHAIN_FILE="${{ steps.vcpkg.outputs.toolchain }}" \
+            -DVCPKG_TARGET_TRIPLET=arch-env
+
+      - name: Build
+        run: cmake --build build/tooling
+
+      - name: Test
+        run: ctest --test-dir build/tooling --output-on-failure
+
+  sanitizer-asan-ubsan-lsan:
+    name: Sanitizer ASAN+UBSAN+LSAN
+    runs-on: ubuntu-latest
+    env:
+      ARCH: x86_64
+      VCPKG_OVERLAY_TRIPLETS: cmake/vcpkg-triplets
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Linuxbrew LLVM
+        shell: bash
+        run: |
+          set -euo pipefail
+          eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+          brew update
+          brew install llvm
+          echo "$(brew --prefix llvm)/bin" >> "$GITHUB_PATH"
+          clang --version
+
+      - name: Resolve vcpkg toolchain
+        id: vcpkg
+        shell: bash
+        run: |
+          set -euo pipefail
+          candidates=()
+          if [ -n "${VCPKG_INSTALLATION_ROOT:-}" ]; then
+            candidates+=("${VCPKG_INSTALLATION_ROOT}/scripts/buildsystems/vcpkg.cmake")
+          fi
+          candidates+=("$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake")
+
+          for candidate in "${candidates[@]}"; do
+            if [ -f "$candidate" ]; then
+              echo "toolchain=$candidate" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          done
+
+          echo "Unable to locate vcpkg toolchain file on runner." >&2
+          exit 1
+
+      - name: Configure
+        shell: bash
+        run: |
+          set -euo pipefail
+          cmake -B build/asan -G Ninja \
+            -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+            -DCMAKE_C_COMPILER=clang \
+            -DCMAKE_CXX_COMPILER=clang++ \
+            -DCMAKE_TOOLCHAIN_FILE="${{ steps.vcpkg.outputs.toolchain }}" \
+            -DVCPKG_TARGET_TRIPLET=arch-env \
+            -DCMAKE_C_FLAGS="-fsanitize=address,undefined,leak -fno-omit-frame-pointer" \
+            -DCMAKE_CXX_FLAGS="-fsanitize=address,undefined,leak -fno-omit-frame-pointer" \
+            -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=address,undefined,leak" \
+            -DCMAKE_SHARED_LINKER_FLAGS="-fsanitize=address,undefined,leak"
+
+      - name: Build
+        run: cmake --build build/asan
+
+      - name: Test
+        run: ctest --test-dir build/asan --output-on-failure
+
+  sanitizer-tsan:
+    name: Sanitizer TSAN
+    runs-on: ubuntu-latest
+    env:
+      ARCH: x86_64
+      VCPKG_OVERLAY_TRIPLETS: cmake/vcpkg-triplets
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Linuxbrew LLVM
+        shell: bash
+        run: |
+          set -euo pipefail
+          eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+          brew update
+          brew install llvm
+          echo "$(brew --prefix llvm)/bin" >> "$GITHUB_PATH"
+          clang --version
+
+      - name: Resolve vcpkg toolchain
+        id: vcpkg
+        shell: bash
+        run: |
+          set -euo pipefail
+          candidates=()
+          if [ -n "${VCPKG_INSTALLATION_ROOT:-}" ]; then
+            candidates+=("${VCPKG_INSTALLATION_ROOT}/scripts/buildsystems/vcpkg.cmake")
+          fi
+          candidates+=("$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake")
+
+          for candidate in "${candidates[@]}"; do
+            if [ -f "$candidate" ]; then
+              echo "toolchain=$candidate" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          done
+
+          echo "Unable to locate vcpkg toolchain file on runner." >&2
+          exit 1
+
+      - name: Configure
+        shell: bash
+        run: |
+          set -euo pipefail
+          cmake -B build/tsan -G Ninja \
+            -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+            -DCMAKE_C_COMPILER=clang \
+            -DCMAKE_CXX_COMPILER=clang++ \
+            -DCMAKE_TOOLCHAIN_FILE="${{ steps.vcpkg.outputs.toolchain }}" \
+            -DVCPKG_TARGET_TRIPLET=arch-env \
+            -DCMAKE_C_FLAGS="-fsanitize=thread -fno-omit-frame-pointer" \
+            -DCMAKE_CXX_FLAGS="-fsanitize=thread -fno-omit-frame-pointer" \
+            -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=thread" \
+            -DCMAKE_SHARED_LINKER_FLAGS="-fsanitize=thread"
+
+      - name: Build
+        run: cmake --build build/tsan
+
+      - name: Test
+        run: ctest --test-dir build/tsan --output-on-failure
+
+  sanitizer-rtsan:
+    name: Sanitizer RTSAN
+    runs-on: ubuntu-latest
+    env:
+      ARCH: x86_64
+      VCPKG_OVERLAY_TRIPLETS: cmake/vcpkg-triplets
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Linuxbrew LLVM
+        shell: bash
+        run: |
+          set -euo pipefail
+          eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+          brew update
+          brew install llvm
+          echo "$(brew --prefix llvm)/bin" >> "$GITHUB_PATH"
+          clang --version
+
+      - name: Resolve vcpkg toolchain
+        id: vcpkg
+        shell: bash
+        run: |
+          set -euo pipefail
+          candidates=()
+          if [ -n "${VCPKG_INSTALLATION_ROOT:-}" ]; then
+            candidates+=("${VCPKG_INSTALLATION_ROOT}/scripts/buildsystems/vcpkg.cmake")
+          fi
+          candidates+=("$HOME/vcpkg/scripts/buildsystems/vcpkg.cmake")
+
+          for candidate in "${candidates[@]}"; do
+            if [ -f "$candidate" ]; then
+              echo "toolchain=$candidate" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          done
+
+          echo "Unable to locate vcpkg toolchain file on runner." >&2
+          exit 1
+
+      - name: Probe realtime sanitizer support
+        id: rtsan-probe
+        shell: bash
+        run: |
+          set -euo pipefail
+          cat > /tmp/rtsan_probe.cpp << 'EOF'
+          int main() { return 0; }
+          EOF
+
+          if clang++ -fsanitize=realtime /tmp/rtsan_probe.cpp -o /tmp/rtsan_probe >/dev/null 2>&1; then
+            echo "supported=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "supported=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Configure
+        if: steps.rtsan-probe.outputs.supported == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          cmake -B build/rtsan -G Ninja \
+            -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+            -DCMAKE_C_COMPILER=clang \
+            -DCMAKE_CXX_COMPILER=clang++ \
+            -DCMAKE_TOOLCHAIN_FILE="${{ steps.vcpkg.outputs.toolchain }}" \
+            -DVCPKG_TARGET_TRIPLET=arch-env \
+            -DCMAKE_C_FLAGS="-fsanitize=realtime -fno-omit-frame-pointer" \
+            -DCMAKE_CXX_FLAGS="-fsanitize=realtime -fno-omit-frame-pointer" \
+            -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=realtime" \
+            -DCMAKE_SHARED_LINKER_FLAGS="-fsanitize=realtime"
+
+      - name: Build
+        if: steps.rtsan-probe.outputs.supported == 'true'
+        run: cmake --build build/rtsan
+
+      - name: Test
+        if: steps.rtsan-probe.outputs.supported == 'true'
+        run: ctest --test-dir build/rtsan --output-on-failure
+
+      - name: RTSAN unavailable note
+        if: steps.rtsan-probe.outputs.supported != 'true'
+        run: |
+          echo "RTSAN is not supported by this LLVM toolchain; skipping job payload."

--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -2,12 +2,6 @@ name: Release Draft
 
 on:
   workflow_dispatch:
-    inputs:
-      ref:
-        description: Git ref to release from (branch, tag, or SHA; defaults to selected branch)
-        required: false
-        default: ""
-        type: string
 
 permissions:
   contents: write
@@ -24,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.ref || github.ref }}
+          ref: ${{ github.ref }}
           fetch-depth: 0
 
       - uses: actions/setup-node@v4
@@ -58,13 +52,10 @@ jobs:
       build_type: Release
       windows_preset: windows-msvc-ninja-release
       windows_artifact_dir: build/windows-msvc-ninja-release
-      run_tests: false
-      include_clang_tidy_linux: false
-      macos_mode: legacy
+      run_tests: true
+      include_clang_tidy_linux: true
       artifact_prefix: release
       cache_key_prefix: release-
-      matrix: >-
-        {"include":[{"name":"linux-x86_64","os":"ubuntu-latest","platform":"linux","arch":"x86_64","triplet":"arch-env"},{"name":"linux-i686","os":"ubuntu-latest","platform":"linux","arch":"i686","triplet":"arch-env"},{"name":"linux-armv7l","os":"ubuntu-latest","platform":"linux","arch":"armv7l","triplet":"arch-env"},{"name":"linux-aarch64","os":"ubuntu-latest","platform":"linux","arch":"aarch64","triplet":"arch-env"},{"name":"windows-x64","os":"windows-2022","platform":"windows","arch":"x64","msvc_arch":"x64","triplet":"x64-windows-static"},{"name":"windows-x86","os":"windows-2022","platform":"windows","arch":"x86","msvc_arch":"x86","triplet":"x86-windows-static"},{"name":"windows-arm64ec","os":"windows-2022","platform":"windows","arch":"arm64ec","msvc_arch":"amd64_arm64","triplet":"arm64ec-windows-static"},{"name":"macos-x86_64","os":"macos-13","platform":"macos","arch":"x86_64","triplet":"arch-env"},{"name":"macos-i386","os":"macos-13","platform":"macos","arch":"i386","triplet":"arch-env","allow_failure":true},{"name":"macos-arm64","os":"macos-14","platform":"macos","arch":"arm64","triplet":"arch-env"}]}
 
   upload-artifacts:
     name: Upload artifacts to draft release


### PR DESCRIPTION
## Summary
- sync `.github/workflows/release-draft.yml` from `refactor` to `main`
- add reusable `.github/workflows/build-matrix.yml` required by release draft and CI
- sync `.github/workflows/ci.yml` to the refactor version to keep workflow set consistent

## Why
`release-draft.yml` on `main` references `build-matrix.yml`, which is missing on `main`.
This PR brings the workflow set to a consistent state and avoids partial cherry-picks that would leave broken references.
